### PR TITLE
Fix: handle process.argv parsing when no command-line arguments provided

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,14 @@ var router = express.Router();
 var getKeyStore = require('../jwt/keyStore.js').getKeyStore;
 var jose = require('node-jose');
 
+const DEFAULT_CLAIMS = JSON.parse(getCommandLineArg("--claims", '{"username": "test@test.com", "userId": 1, "authorities": ["AUTH_1"]}'));
+if (typeof DEFAULT_CLAIMS !== 'object') {
+    throw new Error('Invalid default claims');
+}
+const TOKEN_EXPIRY = Number.parseInt(getCommandLineArg("--token-expiry", 3600));
+if (Number.isNaN(TOKEN_EXPIRY)) {
+    throw new Error('Invalid token expiry');
+}
 
 router.get('/', function(req, res, next) {
   res.json({hello: "world!"});
@@ -22,7 +30,7 @@ router.post('/token', async function(req, res) {
   var key = keys.all()[0];
   var body = req.body;
   body["iat"] = Math.floor(Date.now() / 1000);
-  body["exp"] = Math.floor(Date.now() / 1000) + getTokenExpiry();
+  body["exp"] = Math.floor(Date.now() / 1000) + TOKEN_EXPIRY;
   var token = await new Promise((resolve) => {
     jose.JWS.createSign({ alg: 'RS256', format: 'compact' }, key)
       .update(JSON.stringify(req.body))
@@ -35,24 +43,15 @@ router.post('/token', async function(req, res) {
   res.json({token: token});
 });
 
-function getDefaultJwtClaim() {
-  var index = process.argv.indexOf("--claims");
-  var args = process.argv.slice(index + 1);
-  if (args.length > 0) {
-    return JSON.parse(args[0]);
-  } else {
-    return {"username": "test@test.com", "userId": 1, "authorities": ["AUTH_1"]};
+function getCommandLineArg(flag, defaultValue) {
+  const index = process.argv.indexOf(flag);
+  if (index >= 0) {
+    if (process.argv.length <= index + 1) {
+      throw new Error(`Missing value for ${flag}`);
+    }
+    return process.argv[index + 1];
   }
-}
-
-function getTokenExpiry() {
-  var index = process.argv.indexOf("--token-expiry");
-  var args = process.argv.slice(index + 1);
-  if (args.length > 0) {
-    return JSON.parse(args[0]);
-  } else {
-    return 3600;
-  }
+  return defaultValue;
 }
 
 // router.options('/token', async function(req, res) {
@@ -65,10 +64,10 @@ function getTokenExpiry() {
 router.get('/token', async function(req, res) {
   var keys = await getKeyStore();
   var key = keys.all()[0];
-  var body = Object.keys(req.query).length > 0 ? req.query : getDefaultJwtClaim();
+  var body = Object.keys(req.query).length > 0 ? req.query : DEFAULT_CLAIMS;
 
   body["iat"] = Math.floor(Date.now() / 1000);
-  body["exp"] = Math.floor(Date.now() / 1000) + getTokenExpiry();
+  body["exp"] = Math.floor(Date.now() / 1000) + TOKEN_EXPIRY;
 
   var token = await new Promise((resolve) => {
     jose.JWS.createSign({ alg: 'RS256', format: 'compact' }, key)


### PR DESCRIPTION
Fixes JSON parsing error that occurred when starting the server with just 'npm run start'. Was causing error trying to parse default argv values ( executable and script paths) as JSON claims/expiry. Also parses the arguments at startup rather than on every request to pick configuration error up earlier.

---

Thanks for the project, we're using it and makes testing offline easier.

Started causing error with the latest version as we run it without any arguments, could probably do with validating the values are expected types/format as well but not sure it matters so much for a little mock server like this.